### PR TITLE
ci: remove path ignore

### DIFF
--- a/.github/workflows/code_testing.yml
+++ b/.github/workflows/code_testing.yml
@@ -5,15 +5,6 @@ name: Code Testing
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "*.md"
-      - "*version.txt"
-      - "vscode/**"
-      - "docs/**"
-      - ".github/**"
-      - "!.github/**/*test*.yml"
-      - "!.github/**/*env*.txt"
-      # - "!.github/**/*release*.yml"
   schedule:
     - cron: "0 7 * * 5" # At 07 AM on Friday
 


### PR DESCRIPTION
since the path ignores are not considered by the workflow when they are used as branch protection flows, they are removed to avoid stalled checks.